### PR TITLE
update: model/eventmanager/asset add field

### DIFF
--- a/marketing-api/api/tools/site/create.go
+++ b/marketing-api/api/tools/site/create.go
@@ -3,6 +3,7 @@ package site
 import (
 	"github.com/bububa/oceanengine/marketing-api/core"
 	"github.com/bububa/oceanengine/marketing-api/model/tools/site"
+	"strconv"
 )
 
 // Create 创建橙子建站站点
@@ -12,7 +13,7 @@ import (
 // ①DownloadEvent类型的按钮组件可以填入安卓/IOS下载链接
 // 除以上情况外其他建站组件中的URL参数都不允许填入应用下载链接，如果填入将会创建失败。
 
-// 此接口为创建橙子建站站点，如需进行发布请调用【更改橙子建站站点状态】接口将站点及其落地页发布到线上，未发布则保存在本地，无法使用！
+// Create 此接口为创建橙子建站站点，如需进行发布请调用【更改橙子建站站点状态】接口将站点及其落地页发布到线上，未发布则保存在本地，无法使用！
 // 图片大小需要在2M之内，否则会报错！
 // 创建完成后会返回建站id，建站地址可由如下格式拼装得到：https://www.chengzijianzhan.com/tetris/page/XXXXXXXXXXXXX/（其中XX是建站ID，拼装后就可获得在广告投放流程中使用的投放的URL，以及预览URL）！
 // 快应用链接仅支持以下三类
@@ -24,5 +25,5 @@ func Create(clt *core.SDKClient, accessToken string, req *site.CreateRequest) (u
 	if err := clt.Post("2/tools/site/create/", req, &resp, accessToken); err != nil {
 		return 0, err
 	}
-	return resp.Data.SiteID, nil
+	return strconv.ParseUint(resp.Data.SiteID, 10, 64)
 }

--- a/marketing-api/enum/site_opt_status.go
+++ b/marketing-api/enum/site_opt_status.go
@@ -3,9 +3,22 @@ package enum
 // SiteOptStatus 落地页组站点启用状态
 type SiteOptStatus string
 
+// 落地页组站点启用状态
 const (
 	// SITE_OPT_STATUS_ENABLE 启用
 	SITE_OPT_STATUS_ENABLE SiteOptStatus = "SITE_OPT_STATUS_ENABLE"
 	// SITE_OPT_STATUS_DISABLE 禁用
 	SITE_OPT_STATUS_DISABLE SiteOptStatus = "SITE_OPT_STATUS_DISABLE"
+)
+
+// 站点操作状态
+const (
+	// SITE_OPT_STATUS_PUBLISHED 发布
+	SITE_OPT_STATUS_PUBLISHED SiteOptStatus = "published"
+	// SITE_OPT_STATUS_UNPUBLISHED 下线
+	SITE_OPT_STATUS_UNPUBLISHED SiteOptStatus = "unpublished"
+	// SITE_OPT_STATUS_DELETE 删除
+	SITE_OPT_STATUS_DELETE SiteOptStatus = "delete"
+	//SITE_OPT_STATUS_UNDELETE 恢复删除
+	SITE_OPT_STATUS_UNDELETE SiteOptStatus = "undeleted"
 )

--- a/marketing-api/model/eventmanager/asset.go
+++ b/marketing-api/model/eventmanager/asset.go
@@ -20,6 +20,8 @@ type LandingPage struct {
 // QuickApp 快应用数据
 type QuickApp struct {
 	AssetBaseInfo
+	// Name 快应用名称，长度限制为20，一个字符长度为1
+	Name string `json:"name,omitempty"`
 	// PackageName 快应用包名
 	PackageName string `json:"package_name,omitempty"`
 }
@@ -27,6 +29,10 @@ type QuickApp struct {
 // App 应用数据
 type App struct {
 	AssetBaseInfo
+	// Name 快应用名称，长度限制为20，一个字符长度为1
+	Name string `json:"name,omitempty"`
+	// AppName 应用名
+	AppName string `json:"app_name,omitempty"`
 	// AppType 应用类型
 	AppType string `json:"app_type,omitempty"`
 	// DownloadURL 应用下载链接

--- a/marketing-api/model/tools/site/create.go
+++ b/marketing-api/model/tools/site/create.go
@@ -26,6 +26,6 @@ type CreateResponse struct {
 	// Data json返回值
 	Data struct {
 		// SiteID 站点id
-		SiteID uint64 `json:"site_id,omitempty"`
+		SiteID string `json:"site_id,omitempty"`
 	} `json:"data,omitempty"`
 }


### PR DESCRIPTION
创建事件资产：https://open.oceanengine.com/labels/7/docs/1709792943937547
请求参数：quick_app_asset 和 app_asset 都有 name
获取已创建资产列表：https://open.oceanengine.com/labels/7/docs/1705976384784395
应答字段：app 有 app_name