### PR TITLE
fix: 修复v3接口字段

### DIFF
--- a/marketing-api/model/report/v3/custom_get.go
+++ b/marketing-api/model/report/v3/custom_get.go
@@ -14,6 +14,8 @@ import (
 type CustomGetRequest struct {
 	// AdvertiserID 广告主ID
 	AdvertiserID uint64 `json:"advertiser_id,omitempty"`
+	// DateTopic 数据主题
+	DataTopic string `json:"data_topic"`
 	// Dimensions 维度列表。获取方式：巨量引擎体验版—>报表—>新建/编辑自定义报表—>API参数生成。该字段从前端自定义报表中获取，建议不要修改。
 	Dimensions []string `json:"dimensions,omitempty"`
 	// Metrics 指标列表 。获取方式：巨量引擎体验版—>报表—>新建/编辑自定义报表—>API参数生成。该字段从前端自定义报表中获取，建议不要修改。
@@ -73,6 +75,9 @@ func (r CustomGetRequest) Encode() string {
 	values.Set("end_time", r.EndTime.Format("2006-01-02"))
 	if r.AdvertiserID > 0 {
 		values.Set("advertiser_id", strconv.FormatUint(r.AdvertiserID, 10))
+	}
+	if len(r.DataTopic) > 0 {
+		values.Set("data_topic", r.DataTopic)
 	}
 	if len(r.Dimensions) > 0 {
 		fields, _ := json.Marshal(r.Dimensions)

--- a/marketing-api/model/report/v3/dimensions.go
+++ b/marketing-api/model/report/v3/dimensions.go
@@ -59,7 +59,7 @@ type CustomDimensions struct {
 	// DeepExternalAction 对应项目的深度转化目标
 	DeepExternalAction int `json:"deep_external_action,omitempty"`
 	// AdPlatformCdpProjectDownloadType 在项目中设置的下载方式
-	AdPlatformCdpProjectDownloadType int `json:"ad_platform_cdp_project_download_type,omitempty"`
+	AdPlatformCdpProjectDownloadType string `json:"ad_platform_cdp_project_download_type,omitempty"`
 	// AdPlatformCdpProjectDownloadURL 在项目中设置的下载链接
 	AdPlatformCdpProjectDownloadURL string `json:"ad_platform_cdp_project_download_url,omitempty"`
 	// AdPlatformCdpProjectDownloadActionTrackURL 在项目中设置的监测链接
@@ -75,7 +75,7 @@ type CustomDimensions struct {
 	// AdPlatformCdpPromotionDeepCpaBid 在广告中设置的深度转化出价
 	AdPlatformCdpPromotionDeepCpaBid model.Float64 `json:"ad_platform_cdp_promotion_roi_goal,omitempty"`
 	// AppCode 您所投放的广告数据中，对应的首选广告位
-	AppCode int `json:"app_code,omitempty"`
+	AppCode string `json:"app_code,omitempty"`
 	// PackageName 您在项目中设置的应用包包名
 	PackageName string `json:"package_name,omitempty"`
 	// Gender 您所投放的广告数据中，对应的用户性别。无法识别的性别数据会显示为“其他”

--- a/marketing-api/model/report/v3/metrics.go
+++ b/marketing-api/model/report/v3/metrics.go
@@ -257,8 +257,6 @@ type CustomMetrics struct {
 	AttributionGameInAppRoi7Days model.Float64 `json:"attribution_game_in_app_roi_7days,omitempty"`
 	// AttributionGameInAppRoi8Days 所选时间范围内的激活用户在激活后七日内的整体付费ROI，计算公式是：激活后七日付费金额/所选时间的消耗。
 	AttributionGameInAppRoi8Days model.Float64 `json:"attribution_game_in_app_roi_8days,omitempty"`
-	// AttributionDayActivePayCount 广告计费当日激活且首次付费的次数
-	AttributionDayActivePayCount model.Int64 `json:"attribution_day_acitve_pay_count,omitempty"`
 	// AttributionDayActivePayCost 消耗/计费当日激活且首次付费数
 	AttributionDayActivePayCost model.Float64 `json:"attribution_day_active_pay_cost,omitempty"`
 	// AttributionDayActivePayRate 计费当日激活且首次付费数/激活数


### PR DESCRIPTION
1. app_code, ad_platform_cdp_project_download_type 实际返回值类型为string
2. 增加入参data_topic
3. 返回值无attribution_day_acitve_pay_count, 如果使用反射获取metric field, 会报错
https://open.oceanengine.com/labels/7/docs/1741387668314126