### PR TITLE
fix v3报表的小游戏指标

### DIFF
--- a/marketing-api/model/report/metrics.go
+++ b/marketing-api/model/report/metrics.go
@@ -356,12 +356,14 @@ type Metrics struct {
 	AttributionMicroGame3dLtv float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
 	// AttributionMicroGame7dLtv 小游戏激活后七日LTV-所选时间范围内的激活用户在激活后七日内的变现金额
 	AttributionMicroGame7dLtv float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
-	// AttributionGameInAppRoi1Day 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
-	AttributionGameInAppRoi1Day float64 `json:"attribution_game_in_app_roi_1day,omitempty"`
+	// AttributionMicroGame0dRoi 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
+	AttributionMicroGame0dRoi float64 `json:"attribution_micro_game_0d_roi,omitempty"`
 	// AttributionMicroGame3dRoi 小游戏激活后三日广告变现ROI-所选时间范围内的激活用户在激活后三日内的广告变现ROI，计算公式是：三日LTV / 所选时间的消耗
 	AttributionMicroGame3dRoi float64 `json:"attribution_micro_game_3d_roi,omitempty"`
 	// AttributionMicroGame7dRoi 小游戏激活后七日广告变现ROI-所选时间范围内的激活用户在激活后七日内的广告变现ROI，计算公式是：七日LTV / 所选时间的消耗
 	AttributionMicroGame7dRoi float64 `json:"attribution_micro_game_7d_roi,omitempty"`
 	// AttributionGameInAppLtv1Day 当日付费金额-所选时间范围内的激活用户，激活当日在APP内的付费金额
 	AttributionGameInAppLtv1Day float64 `json:"attribution_game_in_app_ltv_1day,omitempty"`
+	// AttributionGameInAppRoi1Day 当日付费ROI
+	AttributionGameInAppRoi1Day float64 `json:"attribution_game_in_app_roi_1day,omitempty"`
 }

--- a/marketing-api/model/report/v3/dimensions.go
+++ b/marketing-api/model/report/v3/dimensions.go
@@ -98,16 +98,4 @@ type CustomDimensions struct {
 	ImageMode enum.ImageMode `json:"image_mode,omitempty"`
 	// AdPlatformMaterialName 素材为视频素材时，对应的视频名称
 	AdPlatformMaterialName string `json:"ad_platform_material_name,omitempty"`
-	// AttributionMicroGame0dLtv 小游戏当日LTV-所选时间范围内的激活用户在激活当日的变现金额
-	AttributionMicroGame0dLtv float64 `json:"attribution_micro_game_0d_ltv,omitempty"`
-	// AttributionMicroGame3dLtv 小游戏激活后三日LTV-所选时间范围内的激活用户在激活后三日内的变现金额
-	AttributionMicroGame3dLtv float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
-	// AttributionMicroGame7dLtv 小游戏激活后七日LTV-所选时间范围内的激活用户在激活后七日内的变现金额
-	AttributionMicroGame7dLtv float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
-	// AttributionGameInAppRoi1Day 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
-	AttributionGameInAppRoi1Day float64 `json:"attribution_game_in_app_roi_1day,omitempty"`
-	// AttributionMicroGame3dRoi 小游戏激活后三日广告变现ROI-所选时间范围内的激活用户在激活后三日内的广告变现ROI，计算公式是：三日LTV / 所选时间的消耗
-	AttributionMicroGame3dRoi float64 `json:"attribution_micro_game_3d_roi,omitempty"`
-	// AttributionMicroGame7dRoi 小游戏激活后七日广告变现ROI-所选时间范围内的激活用户在激活后七日内的广告变现ROI，计算公式是：七日LTV / 所选时间的消耗
-	AttributionMicroGame7dRoi float64 `json:"attribution_micro_game_7d_roi,omitempty"`
 }

--- a/marketing-api/model/report/v3/metrics.go
+++ b/marketing-api/model/report/v3/metrics.go
@@ -306,15 +306,15 @@ type CustomMetrics struct {
 	// ValidPlayRate 有效播放率, 计算公式：有效播放数/展示数。
 	ValidPlayRate model.Float64 `json:"valid_play_rate,omitempty"`
 	// AttributionMicroGame0dLtv 小游戏当日LTV-所选时间范围内的激活用户在激活当日的变现金额
-	AttributionMicroGame0dLtv float64 `json:"attribution_micro_game_0d_ltv,omitempty"`
+	AttributionMicroGame0dLtv model.Float64 `json:"attribution_micro_game_0d_ltv,omitempty"`
 	// AttributionMicroGame3dLtv 小游戏激活后三日LTV-所选时间范围内的激活用户在激活后三日内的变现金额
-	AttributionMicroGame3dLtv float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
+	AttributionMicroGame3dLtv model.Float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
 	// AttributionMicroGame7dLtv 小游戏激活后七日LTV-所选时间范围内的激活用户在激活后七日内的变现金额
-	AttributionMicroGame7dLtv float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
+	AttributionMicroGame7dLtv model.Float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
 	// AttributionMicroGame0dRoi 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
-	AttributionMicroGame0dRoi float64 `json:"attribution_micro_game_0d_roi,omitempty"`
+	AttributionMicroGame0dRoi model.Float64 `json:"attribution_micro_game_0d_roi,omitempty"`
 	// AttributionMicroGame3dRoi 小游戏激活后三日广告变现ROI-所选时间范围内的激活用户在激活后三日内的广告变现ROI，计算公式是：三日LTV / 所选时间的消耗
-	AttributionMicroGame3dRoi float64 `json:"attribution_micro_game_3d_roi,omitempty"`
+	AttributionMicroGame3dRoi model.Float64 `json:"attribution_micro_game_3d_roi,omitempty"`
 	// AttributionMicroGame7dRoi 小游戏激活后七日广告变现ROI-所选时间范围内的激活用户在激活后七日内的广告变现ROI，计算公式是：七日LTV / 所选时间的消耗
-	AttributionMicroGame7dRoi float64 `json:"attribution_micro_game_7d_roi,omitempty"`
+	AttributionMicroGame7dRoi model.Float64 `json:"attribution_micro_game_7d_roi,omitempty"`
 }

--- a/marketing-api/model/report/v3/metrics.go
+++ b/marketing-api/model/report/v3/metrics.go
@@ -311,8 +311,8 @@ type CustomMetrics struct {
 	AttributionMicroGame3dLtv float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
 	// AttributionMicroGame7dLtv 小游戏激活后七日LTV-所选时间范围内的激活用户在激活后七日内的变现金额
 	AttributionMicroGame7dLtv float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
-	// AttributionGameInAppRoi1Day 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
-	AttributionGameInAppRoi1Day float64 `json:"attribution_game_in_app_roi_1day,omitempty"`
+	// AttributionMicroGame0dRoi 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
+	AttributionMicroGame0dRoi float64 `json:"attribution_micro_game_0d_roi,omitempty"`
 	// AttributionMicroGame3dRoi 小游戏激活后三日广告变现ROI-所选时间范围内的激活用户在激活后三日内的广告变现ROI，计算公式是：三日LTV / 所选时间的消耗
 	AttributionMicroGame3dRoi float64 `json:"attribution_micro_game_3d_roi,omitempty"`
 	// AttributionMicroGame7dRoi 小游戏激活后七日广告变现ROI-所选时间范围内的激活用户在激活后七日内的广告变现ROI，计算公式是：七日LTV / 所选时间的消耗

--- a/marketing-api/model/report/v3/metrics.go
+++ b/marketing-api/model/report/v3/metrics.go
@@ -305,4 +305,16 @@ type CustomMetrics struct {
 	ValidPlayCost model.Float64 `json:"valid_play_cost,omitempty"`
 	// ValidPlayRate 有效播放率, 计算公式：有效播放数/展示数。
 	ValidPlayRate model.Float64 `json:"valid_play_rate,omitempty"`
+	// AttributionMicroGame0dLtv 小游戏当日LTV-所选时间范围内的激活用户在激活当日的变现金额
+	AttributionMicroGame0dLtv float64 `json:"attribution_micro_game_0d_ltv,omitempty"`
+	// AttributionMicroGame3dLtv 小游戏激活后三日LTV-所选时间范围内的激活用户在激活后三日内的变现金额
+	AttributionMicroGame3dLtv float64 `json:"attribution_micro_game_3d_ltv,omitempty"`
+	// AttributionMicroGame7dLtv 小游戏激活后七日LTV-所选时间范围内的激活用户在激活后七日内的变现金额
+	AttributionMicroGame7dLtv float64 `json:"attribution_micro_game_7d_ltv,omitempty"`
+	// AttributionGameInAppRoi1Day 小游戏当日广告变现ROI-所选时间范围内的激活用户在激活当日的广告变现ROI，计算公式是：当日LTV / 所选时间的消耗
+	AttributionGameInAppRoi1Day float64 `json:"attribution_game_in_app_roi_1day,omitempty"`
+	// AttributionMicroGame3dRoi 小游戏激活后三日广告变现ROI-所选时间范围内的激活用户在激活后三日内的广告变现ROI，计算公式是：三日LTV / 所选时间的消耗
+	AttributionMicroGame3dRoi float64 `json:"attribution_micro_game_3d_roi,omitempty"`
+	// AttributionMicroGame7dRoi 小游戏激活后七日广告变现ROI-所选时间范围内的激活用户在激活后七日内的广告变现ROI，计算公式是：七日LTV / 所选时间的消耗
+	AttributionMicroGame7dRoi float64 `json:"attribution_micro_game_7d_roi,omitempty"`
 }


### PR DESCRIPTION
非常抱歉，我上一个提交将v3的指标和维度搞错了。close过了，但是好像晚了一步。

旧版本报表AttributionGameInAppRoi1Day的注释不对，实际为“当日付费ROI”。小游戏当日广告变现ROI实际为attribution_micro_game_0d_roi。
参考文档：https://open.oceanengine.com/labels/7/docs/1696710551666703