### PR TITLE
修复小程序资产回传请求报invalid signature

### DIFF
--- a/marketing-api/api/track/wxa_active.go
+++ b/marketing-api/api/track/wxa_active.go
@@ -50,7 +50,7 @@ func WxaActive(gw string, token string, req *track.WxaActiveRequest, debug bool)
 	if debug {
 		printPostJSONRequest(link, bs)
 	}
-	postReq, err := http.NewRequest("post", link, bytes.NewReader(bs))
+	postReq, err := http.NewRequest("POST", link, bytes.NewReader(bs))
 	if err != nil {
 		return err
 	}

--- a/marketing-api/api/track/wxa_active.go
+++ b/marketing-api/api/track/wxa_active.go
@@ -37,7 +37,7 @@ func WxaActive(gw string, token string, req *track.WxaActiveRequest, debug bool)
 	}
 	h := sha1.New()
 	h.Write(b.Bytes())
-	values.Set("siganture", hex.EncodeToString(h.Sum(nil)))
+	values.Set("signature", hex.EncodeToString(h.Sum(nil)))
 	util.PutBufferPool(b)
 	link := util.StringsJoin(gw, "?", values.Encode())
 	util.PutUrlValues(values)

--- a/marketing-api/api/track/wxa_active.go
+++ b/marketing-api/api/track/wxa_active.go
@@ -56,7 +56,7 @@ func WxaActive(gw string, token string, req *track.WxaActiveRequest, debug bool)
 	}
 	postReq.Header.Set("content-type", "application/json")
 	client:=&http.Client{}
-	resp,err := client.Do(request)
+	resp,err := client.Do(postReq)
 	if err != nil {
 		return err
 	}

--- a/marketing-api/api/track/wxa_active.go
+++ b/marketing-api/api/track/wxa_active.go
@@ -54,8 +54,9 @@ func WxaActive(gw string, token string, req *track.WxaActiveRequest, debug bool)
 	if err != nil {
 		return err
 	}
-	postReq.Header.Add("content-type", "application/json")
-	resp, err := http.DefaultClient.Do(postReq)
+	postReq.Header.Set("content-type", "application/json")
+	client:=&http.Client{}
+	resp,err := client.Do(request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
修复由于 signature 字段名拼写错误，导致的400 invalid signature错误