### PR TITLE
fix(model): 账户余额返回json wallet_total_balance_valid 字段突然 float 变 string

### DIFF
--- a/marketing-api/model/advertiser/fund_get.go
+++ b/marketing-api/model/advertiser/fund_get.go
@@ -82,5 +82,5 @@ type FundGetResponseData struct {
 	// WalletName 钱包名称（广告主账户绑定的共享子钱包名称）
 	WalletName string `json:"wallet_name,omitempty"`
 	// WalletTotalBalanceValid 账户绑定的子钱包的可用共享余额（单位元）
-	WalletTotalBalanceValid float64 `json:"wallet_total_balance_valid,omitempty"`
+	WalletTotalBalanceValid string `json:"wallet_total_balance_valid,omitempty"`
 }


### PR DESCRIPTION
文档地址：https://open.oceanengine.com/labels/7/docs/1696710526192652
log: json: cannot unmarshal string into Go struct field FundGetResponseData.data.wallet_total_balance_valid of type float64
发现最近突然出现报错，莫名其妙了；文档是 number

```json
{
  "code": 0,
  "message": "OK",
  "request_id": "202309011432159234E7A0F8279xxxxx",
  "data": {
    "balance": 263.59,
    "valid_cash": 234.18,
    "return_goods_abs": 0.0,
    "search_grant": 0.0,
    "advertiser_id": 100000000000000,
    "valid_balance": 263.59,
    "cash": 234.18,
    "default_grant": 29.41,
    "valid_grant": 29.41,
    "wallet_id": "1000000000000",
    "wallet_total_balance_valid": "0.0",
    "valid_return_goods_abs": 0.0,
    "name": "",
    "union_grant": 0.0,
    "return_goods_cost": 0.0,
    "grant": 29.41,
    "wallet_name": "",
    "common_grant": 0.0,
    "email": ""
  }
}

```